### PR TITLE
Register providers and route cached

### DIFF
--- a/src/Providers/ModuleProvider.php
+++ b/src/Providers/ModuleProvider.php
@@ -25,6 +25,11 @@ class ModuleProvider extends Provider
     private $packageName;
 
     /**
+     * @var array
+     */
+    protected $providers = [];
+
+    /**
      * Register the application services.
      *
      * @return void
@@ -33,6 +38,7 @@ class ModuleProvider extends Provider
     {
         $this->registerConfiguration();
         $this->registerFactories();
+        $this->registerProviders();
 
         parent::register();
     }
@@ -186,5 +192,15 @@ class ModuleProvider extends Provider
     protected function getLowercasePackageName() : string
     {
         return mb_strtolower($this->getPackageName());
+    }
+
+    /**
+     * @return void
+     */
+    protected function registerProviders() : void
+    {
+        foreach ($this->providers as $provider) {
+            $this->app->register($provider);
+        }
     }
 }

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -84,6 +84,8 @@ abstract class Provider extends ServiceProvider
      */
     protected function mapRoutes() : void
     {
+        if($this->app->routesAreCached() === true) return;
+
         foreach ($this->routers as $router) {
             $this->app->make($router);
         }


### PR DESCRIPTION
## PR Type

What kind of pull request is this? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Extend feature (non-breaking change which extends existing functionality)
- [ ] Change feature (non-breaking change which either changes or refactors existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## What does it change?

- Route cached
- Registration of providers by specifying them in the main provider of the module.

## Why this PR?

The module loader loads only one provider, and if there are several of them or there are several deferred providers.
My editing allows the main provider to specify a list of other providers for the operation of the module.

## How has this been tested?

```php
declare(strict_types=1);

namespace User\Providers;

use SebastiaanLuca\Module\Providers\ModuleProvider;
use User\Http\Routers\UserAuthRouter;

class UserServiceProvider extends ModuleProvider
{
    protected $routers = [
        UserAuthRouter::class
    ];

    protected $providers = [
        UserTestServiceProvider::class
    ];

    /**
     * Register the application services.
     *
     * @return void
     */
    public function register() : void
    {
        parent::register();
    }

    /**
     * Bootstrap the application services.
     *
     * @return void
     */
    public function boot() : void
    {
        parent::boot();
    }
}
```

## Checklist

To facilitate merging your change and the approval of this PR, please make sure you've reviewed and applied the following:

- This PR addresses exactly one issue
- All changes were made in a fork of this project (preferably also in a separate branch)
- It follows the code style of this project
- Tests were added to cover the changes
- All previously existing tests still pass
- If the change to the code requires a change to the documentation, it has been updated accordingly

If you're unsure about any of these, don't hesitate to ask. We're here to help!
