### PR TITLE
Auto register module providers

### DIFF
--- a/src/Providers/ModuleProvider.php
+++ b/src/Providers/ModuleProvider.php
@@ -25,6 +25,11 @@ class ModuleProvider extends Provider
     private $packageName;
 
     /**
+     * @var array
+     */
+    protected $providers = [];
+
+    /**
      * Register the application services.
      *
      * @return void
@@ -33,6 +38,7 @@ class ModuleProvider extends Provider
     {
         $this->registerConfiguration();
         $this->registerFactories();
+        $this->registerProviders();
 
         parent::register();
     }
@@ -186,5 +192,15 @@ class ModuleProvider extends Provider
     protected function getLowercasePackageName() : string
     {
         return mb_strtolower($this->getPackageName());
+    }
+
+    /**
+     * @return void
+     */
+    protected function registerProviders() : void
+    {
+        foreach ($this->providers as $provider) {
+            $this->app->register($provider);
+        }
     }
 }


### PR DESCRIPTION
## PR Type

What kind of pull request is this? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Extend feature (non-breaking change which extends existing functionality)
- [ ] Change feature (non-breaking change which either changes or refactors existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## What does it change?

- Registration of providers by specifying them in the main provider of the module.

## Why this PR?

The module loader loads only one provider, and if there are several of them or there are several deferred providers.
My editing allows the main provider to specify a list of other providers for the operation of the module.

## How has this been tested?

```php
declare(strict_types=1);

namespace User\Providers;

use SebastiaanLuca\Module\Providers\ModuleProvider;
use User\Http\Routers\UserAuthRouter;

class UserServiceProvider extends ModuleProvider
{
    protected $routers = [
        UserAuthRouter::class
    ];

    protected $providers = [
        UserTestServiceProvider::class
    ];

    /**
     * Register the application services.
     *
     * @return void
     */
    public function register() : void
    {
        parent::register();
    }

    /**
     * Bootstrap the application services.
     *
     * @return void
     */
    public function boot() : void
    {
        parent::boot();
    }
}
```
